### PR TITLE
New default PORTDIR, PKGDIR, and DISTDIR settings approved by council

### DIFF
--- a/README
+++ b/README
@@ -52,7 +52,7 @@ distribution tarball's files directory.
 
 Example catalyst.conf:
 
-distdir="/usr/portage/distfiles"
+distdir="/var/cache/distfiles"
 options="pkgcache kerncache"
 sharedir="/usr/share/catalyst"
 

--- a/catalyst/base/stagebase.py
+++ b/catalyst/base/stagebase.py
@@ -1020,7 +1020,7 @@ class StageBase(TargetBase, ClearBase, GenBase):
 					ouch = 1
 					log.warning("Couldn't umount bind mount: %s", target)
 
-			if "snapcache" in self.settings["options"] and x == "/usr/portage":
+			if "snapcache" in self.settings["options"] and x == "/var/db/repos/gentoo":
 				try:
 					# It's possible the snapshot lock object isn't created yet.
 					# This is because mount safety check calls unbind before the

--- a/doc/catalyst-config.5.txt
+++ b/doc/catalyst-config.5.txt
@@ -31,14 +31,14 @@ envscript="/etc/catalyst/catalystrc"
 options="autoresume bindist kerncache pkgcache seedcache snapcache"
 
 # source repo settings
-distdir="/usr/portage/distfiles"
-portdir="/usr/portage"
+distdir="/var/cache/distfiles"
+portdir="/var/db/repos/gentoo"
 
 # target repo info
-repo_basedir="/usr"
-repo_name="portage"
-target_distdir="/usr/portage/distfiles"
-target_pkgdir="/usr/portage/packages"
+repo_basedir="/var/db/repos"
+repo_name="gentoo"
+target_distdir="/var/cache/distfiles"
+target_pkgdir="/var/cache/binpkgs"
 
 # other catalyst settings
 sharedir="/usr/share/catalyst"
@@ -156,17 +156,16 @@ Repository settings
 
 *distdir*::
 Source distfiles location used in generation of the stages.  This is usually the
-hosts distfiles location.  `/usr/portage/distfiles` should work for most
+hosts distfiles location.  `/var/cache/distfiles` should work for most
 default installations, but it should be set to match your hosts configuration.
 
 *portdir*::
-Source Gentoo tree location (primary repo). `/usr/portage/` should work for most
+Source Gentoo tree location (primary repo). `/var/db/repos/gentoo/` should work for most
 default installations.
 
 *repo_basedir*::
-The target repository directory to contain the rimary repo (gentoo repo) and
-any overlays.  `/usr` is the historical location. But that is in the process of
-changing.  `/var/gentoo/repos` is an option.
+The target repository directory to contain the primary repo (gentoo repo) and
+any overlays.  The default location is `/var/db/repos`.
 
 *repo_name*::
 The name of the main repository (ie: gentoo).  This has had a directory name
@@ -180,12 +179,12 @@ internal repo_name value should be the same.
 This is the target distfiles directory location for the stage being created.
 This is important because this value will be stored in the stage's make.conf
 and will become the default location used if it is not edited by users.
-The default location is `/usr/portage/distfiles`.
+The default location is `/var/cache/distfiles`.
 
 *target_pkgdir*::
 This is the target packages directory for storing binpkgs in the stage being
 built.  This location is stored in the make.conf of the stage being built.
-The default location for this has typically been `/usr/portage/packages`
+The default location for this has typically been `/var/cache/binpkgs`
 
 Other settings
 ~~~~~~~~~~~~~~

--- a/etc/catalyst.conf
+++ b/etc/catalyst.conf
@@ -28,7 +28,7 @@ contents="auto"
 
 # distdir specifies where your distfiles are located. This setting should
 # work fine for most default installations.
-distdir="/usr/portage/distfiles"
+distdir="/var/cache/distfiles"
 
 # envscript allows users to set options such as http proxies, MAKEOPTS,
 # GENTOO_MIRRORS, or any other environment variables needed for building.
@@ -84,18 +84,18 @@ hash_function="crc32"
 options="autoresume bindist kerncache pkgcache seedcache snapcache"
 
 # Source portdir specifies the source portage tree used by the snapshot target.
-portdir="/usr/portage"
+portdir="/var/db/repos/gentoo"
 
 # Target portdir setting.  It needs to be in 2 parts.
 # They will be used separately, then added together where needed.
 # eg:
-# repo_basedir="/var/lib/repos"
+# repo_basedir="/var/db/repos"
 # repo_name="gentoo"
 #
-repo_basedir="/usr"
-repo_name="portage"
-target_distdir="/usr/portage/distfiles"
-target_pkgdir="/usr/portage/packages"
+repo_basedir="/var/db/repos"
+repo_name="gentoo"
+target_distdir="/var/cache/distfiles"
+target_pkgdir="/var/cache/binpkgs"
 
 # sharedir specifies where all of the catalyst runtime executables
 # and other shared lib objects are.

--- a/examples/generic_stage_template.spec
+++ b/examples/generic_stage_template.spec
@@ -28,7 +28,7 @@ target:
 rel_type:
 
 # This is the system profile to be used by catalyst to build this target.  It is
-# specified as a relative path from /usr/portage/profiles.
+# specified as a relative path from /var/db/repos/gentoo/profiles.
 # example:
 # profile: default-linux/x86/2006.1
 profile:

--- a/examples/grp_template.spec
+++ b/examples/grp_template.spec
@@ -28,7 +28,7 @@ target: grp
 rel_type:
 
 # This is the system profile to be used by catalyst to build this target.  It is
-# specified as a relative path from /usr/portage/profiles.
+# specified as a relative path from /var/db/repos/gentoo/profiles.
 # example:
 # profile: default-linux/x86/2006.1
 profile:

--- a/examples/livecd-stage1_template.spec
+++ b/examples/livecd-stage1_template.spec
@@ -28,7 +28,7 @@ target:
 rel_type:
 
 # This is the system profile to be used by catalyst to build this target.  It is
-# specified as a relative path from /usr/portage/profiles.
+# specified as a relative path from /var/db/repos/gentoo/profiles.
 # example:
 # profile: default-linux/x86/2006.1
 profile:

--- a/examples/livecd-stage2_template.spec
+++ b/examples/livecd-stage2_template.spec
@@ -28,7 +28,7 @@ target:
 rel_type:
 
 # This is the system profile to be used by catalyst to build this target.  It is
-# specified as a relative path from /usr/portage/profiles.
+# specified as a relative path from /var/db/repos/gentoo/profiles.
 # example:
 # profile: default-linux/x86/2006.1
 profile:
@@ -354,7 +354,7 @@ livecd/unmerge:
 # rid of files that don't belong to a particular package, or removing files from
 # a package that you wish to keep, but won't need the full functionality.
 # example:
-# livecd/empty: /var/tmp /var/cache /var/db /var/empty /var/lock /var/log /var/run /var/spool /var/state /tmp /usr/portage /usr/share/man /usr/share/info /usr/share/unimaps /usr/include /usr/share/zoneinfo /usr/share/dict /usr/share/doc /usr/share/ss /usr/share/state /usr/share/texinfo /usr/lib/python2.2 /usr/lib/portage /usr/share/gettext /usr/share/i18n /usr/share/rfc /usr/lib/X11/config /usr/lib/X11/etc /usr/lib/X11/doc /usr/src /usr/share/doc /usr/share/man /etc/cron.daily /etc/cron.hourly /etc/cron.monthly /etc/cron.weekly /etc/logrotate.d /etc/rsync /usr/lib/awk /usr/lib/ccache /usr/lib/gcc-config /usr/lib/nfs /usr/local /usr/diet/include /usr/diet/man /usr/share/consolefonts/partialfonts /usr/share/consoletrans /usr/share/emacs /usr/share/gcc-data /usr/share/genkernel /etc/bootsplash/gentoo /etc/bootsplash/gentoo-highquality /etc/splash/gentoo /etc/splash/emergence /usr/share/gnuconfig /usr/share/lcms /usr/share/locale /etc/skel
+# livecd/empty: /var/tmp /var/cache /var/db /var/empty /var/lock /var/log /var/run /var/spool /var/state /tmp /var/db/repos/gentoo /usr/share/man /usr/share/info /usr/share/unimaps /usr/include /usr/share/zoneinfo /usr/share/dict /usr/share/doc /usr/share/ss /usr/share/state /usr/share/texinfo /usr/lib/python2.2 /usr/lib/portage /usr/share/gettext /usr/share/i18n /usr/share/rfc /usr/lib/X11/config /usr/lib/X11/etc /usr/lib/X11/doc /usr/src /usr/share/doc /usr/share/man /etc/cron.daily /etc/cron.hourly /etc/cron.monthly /etc/cron.weekly /etc/logrotate.d /etc/rsync /usr/lib/awk /usr/lib/ccache /usr/lib/gcc-config /usr/lib/nfs /usr/local /usr/diet/include /usr/diet/man /usr/share/consolefonts/partialfonts /usr/share/consoletrans /usr/share/emacs /usr/share/gcc-data /usr/share/genkernel /etc/bootsplash/gentoo /etc/bootsplash/gentoo-highquality /etc/splash/gentoo /etc/splash/emergence /usr/share/gnuconfig /usr/share/lcms /usr/share/locale /etc/skel
 livecd/empty:
 
 # This option tells catalyst to clean specific files from the filesystem and is

--- a/examples/netboot_template.spec
+++ b/examples/netboot_template.spec
@@ -28,7 +28,7 @@ target:
 rel_type:
 
 # This is the system profile to be used by catalyst to build this target.  It is
-# specified as a relative path from /usr/portage/profiles.
+# specified as a relative path from /var/db/repos/gentoo/profiles.
 # example:
 # profile: default-linux/x86/2006.1
 profile:

--- a/examples/stage4_template.spec
+++ b/examples/stage4_template.spec
@@ -28,7 +28,7 @@ target:
 rel_type:
 
 # This is the system profile to be used by catalyst to build this target.  It is
-# specified as a relative path from /usr/portage/profiles.
+# specified as a relative path from /var/db/repos/gentoo/profiles.
 # example:
 # profile: default-linux/x86/2006.1
 profile:
@@ -252,7 +252,7 @@ stage4/unmerge:
 # rid of files that don't belong to a particular package, or removing files from
 # a package that you wish to keep, but won't need the full functionality.
 # example:
-# stage4/empty: /var/tmp /var/cache /var/db /var/empty /var/lock /var/log /var/run /var/spool /var/state /tmp /usr/portage /usr/share/man /usr/share/info /usr/share/unimaps /usr/include /usr/share/zoneinfo /usr/share/dict /usr/share/doc /usr/share/ss /usr/share/state /usr/share/texinfo /usr/lib/python2.2 /usr/lib/portage /usr/share/gettext /usr/share/i18n /usr/share/rfc /usr/lib/X11/config /usr/lib/X11/etc /usr/lib/X11/doc /usr/src /usr/share/doc /usr/share/man /etc/cron.daily /etc/cron.hourly /etc/cron.monthly /etc/cron.weekly /etc/logrotate.d /etc/rsync /usr/lib/awk /usr/lib/ccache /usr/lib/gcc-config /usr/lib/nfs /usr/local /usr/diet/include /usr/diet/man /usr/share/consolefonts/partialfonts /usr/share/consoletrans /usr/share/emacs /usr/share/gcc-data /usr/share/genkernel /etc/splash/gentoo /etc/splash/emergence /usr/share/gnuconfig /usr/share/lcms /usr/share/locale /etc/skel
+# stage4/empty: /var/tmp /var/cache /var/db /var/empty /var/lock /var/log /var/run /var/spool /var/state /tmp /var/db/repos/gentoo /usr/share/man /usr/share/info /usr/share/unimaps /usr/include /usr/share/zoneinfo /usr/share/dict /usr/share/doc /usr/share/ss /usr/share/state /usr/share/texinfo /usr/lib/python2.2 /usr/lib/portage /usr/share/gettext /usr/share/i18n /usr/share/rfc /usr/lib/X11/config /usr/lib/X11/etc /usr/lib/X11/doc /usr/src /usr/share/doc /usr/share/man /etc/cron.daily /etc/cron.hourly /etc/cron.monthly /etc/cron.weekly /etc/logrotate.d /etc/rsync /usr/lib/awk /usr/lib/ccache /usr/lib/gcc-config /usr/lib/nfs /usr/local /usr/diet/include /usr/diet/man /usr/share/consolefonts/partialfonts /usr/share/consoletrans /usr/share/emacs /usr/share/gcc-data /usr/share/genkernel /etc/splash/gentoo /etc/splash/emergence /usr/share/gnuconfig /usr/share/lcms /usr/share/locale /etc/skel
 stage4/empty:
 
 # This option tells catalyst to clean specific files from the filesystem and is

--- a/examples/tinderbox_template.spec
+++ b/examples/tinderbox_template.spec
@@ -26,7 +26,7 @@ target: tinderbox
 rel_type:
 
 # This is the system profile to be used by catalyst to build this target.  It is
-# specified as a relative path from /usr/portage/profiles.
+# specified as a relative path from /var/db/repos/gentoo/profiles.
 # example:
 # profile: default-linux/x86/2006.1
 profile:

--- a/livecd/files/livecd-local.start
+++ b/livecd/files/livecd-local.start
@@ -16,10 +16,10 @@
 
 if [ -d /usr/livecd/profiles ]
 then
-	ln -sf /usr/livecd/profiles /usr/portage/profiles
+	ln -sf /usr/livecd/profiles /var/db/repos/gentoo/profiles
 fi
 
 if [ -d /usr/livecd/eclass ]
 then
-	ln -sf /usr/livecd/eclass /usr/portage/eclass
+	ln -sf /usr/livecd/eclass /var/db/repos/gentoo/eclass
 fi


### PR DESCRIPTION
The locations approved by the council:
```
DISTDIR="/var/cache/distfiles"
PKGDIR="/var/cache/binpkgs"
PORTDIR="/var/db/repos/gentoo"
```
Bug: https://bugs.gentoo.org/684908