### PR TITLE
Fix bugzilla:784218

### DIFF
--- a/targets/support/kmerge.sh
+++ b/targets/support/kmerge.sh
@@ -12,7 +12,7 @@ genkernel_compile() {
 		--no-mountboot
 		--kerneldir=/usr/src/linux
 		--modulespackage=/tmp/kerncache/${kname}-modules-${clst_version_stamp}.tar.bz2
-		--minkernpackage=/tmp/kerncache/${kname}-kernel-initrd-${clst_version_stamp}.tar.bz2 all
+		--minkernpackage=/tmp/kerncache/${kname}-kernel-initrd-${clst_version_stamp}.tar.bz2 #let the user specify "all" or "kernel" in livecd/gk_mainargs
 	)
 	# extra genkernel options that we have to test for
 	if [[ -n ${clst_gk_mainargs} ]]; then


### PR DESCRIPTION
As the [upstream bug reference](https://bugs.gentoo.org/784218) in the title explains in detail, defaulting to `genkernel all` as opposed to letting the user configure his or her .spec file to run `genkernel kernel --callback=dracut` presents a problem for those who are trying to build graphical live media with Plymouth support. So, I'm submitting this pull request to (partially) resolve that problem; those who maintain the releng .spec files might need to update them to add "all" to `livecd/gk_mainargs` in those cases.