### PR TITLE
fix inconsistent tabbing error

### DIFF
--- a/catalyst/base/stagebase.py
+++ b/catalyst/base/stagebase.py
@@ -597,7 +597,7 @@ class StageBase(TargetBase, ClearBase, GenBase):
             self.settings["groups"] = []
         log.info('groups to create: %s' % self.settings["groups"])
 
-	def set_users(self):
+    def set_users(self):
         users = self.settings["spec_prefix"] + "/users"
         if users in self.settings:
             if isinstance(self.settings[users], str):


### PR DESCRIPTION
Prior to patch I saw this error under python 3.10:

```
running build_scripts
creating /var/tmp/portage/dev-util/catalyst-9999/work/catalyst-9999-python3_10/scripts
copying and adjusting bin/catalyst -> /var/tmp/portage/dev-util/catalyst-9999/work/catalyst-9999-python3_10/scripts
changing mode of /var/tmp/portage/dev-util/catalyst-9999/work/catalyst-9999-python3_10/scripts/catalyst from 644 to 755
 * Using python3.10 in global scope
 * python3_10: running distutils-r1_run_phase python_compile_all
make -j16
a2x --conf-file=doc/asciidoc.conf --attribute="catalystversion=9999" \
        --format=manpage -D files "doc/catalyst-config.5.txt"
./doc/make_subarch_table_guidexml.py
PYTHONPATH=. "./doc/make_target_table.py" > "doc/targets.generated.txt"
a2x --conf-file=doc/asciidoc.conf --attribute="catalystversion=9999" \
        --format=xhtml -D files "doc/HOWTO.txt"
a2x --conf-file=doc/asciidoc.conf --attribute="catalystversion=9999" \
        --format=manpage -D files "doc/catalyst.1.txt"
Traceback (most recent call last):
  File "/var/tmp/portage/dev-util/catalyst-9999/work/catalyst-9999/./doc/make_target_table.py", line 45, in <module>
    main(sys.argv[1:])
  File "/var/tmp/portage/dev-util/catalyst-9999/work/catalyst-9999/./doc/make_target_table.py", line 32, in main
    __import__(module_name)
  File "/var/tmp/portage/dev-util/catalyst-9999/work/catalyst-9999/catalyst/targets/stage1.py", line 9, in <module>
    from catalyst.base.stagebase import StageBase
  File "/var/tmp/portage/dev-util/catalyst-9999/work/catalyst-9999/catalyst/base/stagebase.py", line 600
    def set_users(self):
TabError: inconsistent use of tabs and spaces in indentation
make: *** [Makefile:34: doc/targets.generated.txt] Error 1
```