### PR TITLE
targets/stage1/chroot.sh: build initial baselayout with USE=build

### DIFF
--- a/targets/stage1/chroot.sh
+++ b/targets/stage1/chroot.sh
@@ -61,9 +61,9 @@ mkdir -p "$ROOT"
 
 ## START BUILD
 # First, we drop in a known-good baselayout
-[ -e ${clst_make_conf} ] && echo "USE=\"${USE} -build\"" >> ${clst_make_conf}
+[ -e ${clst_make_conf} ] && echo "USE=\"${USE} build\"" >> ${clst_make_conf}
 run_merge --oneshot --nodeps sys-apps/baselayout
-sed -i "/USE=\"${USE} -build\"/d" ${clst_make_conf}
+sed -i "/USE=\"${USE} build\"/d" ${clst_make_conf}
 
 echo "$locales" > /etc/locale.gen
 for etc in /etc "$ROOT"/etc; do


### PR DESCRIPTION
current flow is the following:
* update seed
* install baselayout with USE=-build (for reasons unknown)
* install @system with USE=build, which also pulls baselayout

this leads to a problem on usrmerged systems, because baselayout with USE=-build that's installed initially does not create usrmerge symlinks at all, so /bin /sbin are missing.

anything that installs files to those locations will be lost.

after installing baselayout initially with USE=-build --nodeps we install the following
bzip2
gzip
tar
xz-utils
baselayout[build]

so everything installed before line above ^ looses / files completely.

This commit will change initial baselayout to USE=build

Thanks-to: Mike Gilbert <floppym@gentoo.org>
Signed-off-by: Georgy Yakovlev <gyakovlev@gentoo.org>