### PR TITLE
targets/support/pre-kmerge.sh: fix comparison operator

### DIFF
--- a/targets/support/pre-kmerge.sh
+++ b/targets/support/pre-kmerge.sh
@@ -18,8 +18,8 @@ if [[ ${clst_hostarch} == hppa ]]; then
 				;;
 		esac
 	done
-	[[ $num32 > 1 ]] && die "Only one 32-bit kernel can be configured"
-	[[ $num64 > 1 ]] && die "Only one 64-bit kernel can be configured"
+	[[ $num32 -gt 1 ]] && die "Only one 32-bit kernel can be configured"
+	[[ $num64 -gt 1 ]] && die "Only one 64-bit kernel can be configured"
 fi
 
 run_merge --oneshot sys-kernel/genkernel


### PR DESCRIPTION
'<' and '>' work lexicographically in bash.

Signed-off-by: Sam James <sam@gentoo.org>