### PR TITLE
arch: add new x86.i686-ssemath subprofile

### DIFF
--- a/arch/x86.toml
+++ b/arch/x86.toml
@@ -27,24 +27,12 @@ CPU_FLAGS_X86 = [ "mmx",]
 COMMON_FLAGS = "-O2 -march=pentium3 -pipe"
 CPU_FLAGS_X86 = [ "mmx", "mmxext", "sse",]
 
-[x86.pentium-m]
-COMMON_FLAGS = "-O2 -march=pentium-m -pipe"
-CPU_FLAGS_X86 = [ "mmx", "mmxext", "sse", "sse2",]
-
-[x86.pentium4]
-COMMON_FLAGS = "-O2 -march=pentium4 -pipe"
-CPU_FLAGS_X86 = [ "mmx", "mmxext", "sse", "sse2",]
-
 [x86.pentiumpro]
 COMMON_FLAGS = "-O2 -march=i686 -pipe"
 
 [x86.pentium-mmx]
 COMMON_FLAGS = "-O2 -march=pentium-mmx -pipe"
 CPU_FLAGS_X86 = [ "mmx",]
-
-[x86.prescott]
-COMMON_FLAGS = "-O2 -march=prescott -pipe"
-CPU_FLAGS_X86 = [ "mmx", "mmxext", "sse", "sse2", "sse3",]
 
 [x86.k6]
 COMMON_FLAGS = "-O2 -march=k6 -pipe"

--- a/arch/x86.toml
+++ b/arch/x86.toml
@@ -50,3 +50,6 @@ CPU_FLAGS_X86 = [ "mmx", "mmxext", "3dnow", "3dnowext",]
 COMMON_FLAGS = "-O2 -march=athlon-xp -pipe"
 CPU_FLAGS_X86 = [ "mmx", "mmxext", "3dnow", "3dnowext", "sse",]
 
+[x86.i686-ssemath]
+COMMON_FLAGS = "-O2 -march=i686 -msse2 -mfpmath=sse -pipe"
+CPU_FLAGS_X86 = [ "mmx", "mmxext", "sse", "sse2",]


### PR DESCRIPTION
As mentioned on the mailing list, x86 arch testing needs to be performed using SSE registers for floating-point math instead of the 387 FPU. This is a subprofile which provides a generic i686 target with SSE2 and `-mfpmath=sse`.  The use is not just limited to arch testing however as this is a useful platform for getting maximum performance on late-gen chips.  Per gcc:

> The resulting code should be considerably faster in the majority of cases and avoid the numerical instability problems of 387 code, but may break some existing code that expects temporaries to be 80 bits.

Of course modern code has quite the opposite problem, where it does not expect floating-point variables to be 80 bits.