### PR TITLE
Explicitly declare repo as main when it does not match the default main

### DIFF
--- a/catalyst/base/stagebase.py
+++ b/catalyst/base/stagebase.py
@@ -921,6 +921,12 @@ class StageBase(TargetBase, ClearBase, GenBase):
                 continue
 
             config = configparser.ConfigParser()
+
+            # If default is present but does not match this repo's location,
+            # then we need to explicitly set it as the main repo.
+            if default is not None:
+                config['DEFAULT'] = {'main-repo': name}
+
             config[name] = {'location': location}
             self.write_repo_conf(name, config)
 


### PR DESCRIPTION
Otherwise Portage complains about PORTDIR not being set.