### PR TITLE
kmerge.sh: use the module directory name for --kver

### DIFF
--- a/targets/support/kmerge.sh
+++ b/targets/support/kmerge.sh
@@ -160,7 +160,8 @@ if [[ ${distkernel} = "yes" ]] ; then
   # Kernel already built, let's run dracut to make initramfs
   distkernel_source_path=$(equery -Cq f ${ksource} | grep "/usr/src/linux-" -m1)
   distkernel_image_path=$(distkmerge_get_image_path)
-  distkernel_version=${distkernel_source_path##"/usr/src/linux-"}
+  distkernel_mod_dir=$(ls -dt /lib/modules/* | head -1) # get the most recently modified kernel
+  distkernel_version=${distkernel_mod_dir##"/lib/modules/"}
 
   DRACUT_ARGS=(
     "${kernel_dracut_kernargs[@]}"


### PR DESCRIPTION
Dracut expects --kver to match the module directory name exactly, so we should use it. This fixes odd behaviour when the dist-kernel's PV does not _exactly_ match the built kernel's version, e.g. when PV="x.y.z_pA" and KVER="x.y.z-pA".

We get the last modified module dir so that the correct initramfs gets built for each call of kmerge.sh.

Beyond making kmerge.sh's behaviour "correct" from Dracut's perspective, this is necessary to build Gentoo Asahi install media (or any other project that relies on similar funnily-versioned unstable kernels)