### PR TITLE
stagebase: set basearch to gentoo arch

### DIFF
--- a/catalyst/base/stagebase.py
+++ b/catalyst/base/stagebase.py
@@ -127,6 +127,7 @@ class StageBase(TargetBase, ClearBase, GenBase):
 
                 # Search for a subarchitecture in each arch in the arch_config
                 for arch in [x for x in arch_config if x.startswith(name) and host in arch_config[x]]:
+                    self.settings['basearch'] = arch
                     self.settings.update(arch_config[arch][host])
                     setarch = arch_config.get('setarch', {}).get(arch, {})
                     break


### PR DESCRIPTION
I'll rewrite this some other time, but this fixes an issue with distkernel support (dracut gets called with `"--kernel-image=/usr/src/linux-6.6.32-gentoo-dist/unsupported ARCH="`).  Having the base Gentoo arch available is useful either way.