### PR TITLE
Copy vmlinux if it was generated instead of vmlinuz

### DIFF
--- a/targets/support/functions.sh
+++ b/targets/support/functions.sh
@@ -83,6 +83,10 @@ extract_kernels() {
 		then
 			mv ${1}/vmlinuz-* ${1}/${x}
 		fi
+		if [ -e ${1}/vmlinux-* ]
+		then
+			mv ${1}/vmlinux-* ${1}/${x}
+		fi
 
 		# change initrd name from "initrd" to "gentoo.igz", for example
 		if [ -e ${1}/initrd-* ]

--- a/targets/support/kmerge.sh
+++ b/targets/support/kmerge.sh
@@ -173,7 +173,7 @@ if [[ ${distkernel} = "yes" ]] ; then
 
   # Create minkernel package to mimic genkernel's behaviour
   cd /boot
-  tar jcvf /tmp/kerncache/${kname}-kernel-initrd-${clst_version_stamp}.tar.bz2 System.map* config* initramfs* vmlinuz*
+  tar jcvf /tmp/kerncache/${kname}-kernel-initrd-${clst_version_stamp}.tar.bz2 System.map* config* initramfs* vmlinuz* vmlinux*
   cd /
   tar jcvf /tmp/kerncache/${kname}-modules-${clst_version_stamp}.tar.bz2 lib/modules
 


### PR DESCRIPTION
When building ISO for PPC64 with dist-kernel, it generates vmlinux uncompressed image. Previously only vmlinuz was moved to livecd boot directory, so in that case, we ended up with missing kernel file inside ISO /boot. This patch adds vmlinuz file check and copies it if it's found.