### PR TITLE
Persistent memory support for hybrid ISOs

### DIFF
--- a/catalyst/base/stagebase.py
+++ b/catalyst/base/stagebase.py
@@ -1791,8 +1791,13 @@ class StageBase(TargetBase, ClearBase, GenBase):
                 'Resume point detected, skipping build_packages operation...')
             return
 
-        cmd([self.settings['controller_file'], 'livecd-update'],
-            env=self.env)
+        if self.settings["spec_prefix"] + "/iso_extra_partition" in self.settings:
+            cmd([self.settings['controller_file'], 'livecd-update', '/mnt/storage'],
+                env=self.env)
+        else:
+            cmd([self.settings['controller_file'], 'livecd-update'],
+                env=self.env)
+
         self.resume.enable("livecd_update")
 
     def diskimage_update(self):

--- a/catalyst/base/stagebase.py
+++ b/catalyst/base/stagebase.py
@@ -1639,8 +1639,13 @@ class StageBase(TargetBase, ClearBase, GenBase):
 
         # Create the ISO
         if "iso" in self.settings:
-            cmd([self.settings['controller_file'], 'iso', self.settings['iso']],
-                env=self.env)
+            if self.settings["spec_prefix"] + "/iso_extra_partition" in self.settings:
+                cmd([self.settings['controller_file'], 'iso', self.settings['iso'],
+                    self.settings[self.settings["spec_prefix"] + "/iso_extra_partition"]],
+                    env=self.env)
+            else:
+                cmd([self.settings['controller_file'], 'iso', self.settings['iso']],
+                    env=self.env)
             self.gen_contents_file(self.settings["iso"])
             self.gen_digest_file(self.settings["iso"])
             self.resume.enable("create_iso")

--- a/catalyst/targets/livecd_stage2.py
+++ b/catalyst/targets/livecd_stage2.py
@@ -25,6 +25,7 @@ class livecd_stage2(StageBase):
         "livecd/fstype",
         "livecd/gk_mainargs",
         "livecd/iso",
+        "livecd/iso_extra_partition",
         "livecd/linuxrc",
         "livecd/modblacklist",
         "livecd/motd",

--- a/doc/catalyst-spec.5.txt
+++ b/doc/catalyst-spec.5.txt
@@ -180,6 +180,17 @@ This is the full path and filename to the ISO image that the
 livecd-stage2 target will create (example:
 `/tmp/installcd-x86-minimal.iso`).
 
+*livecd/iso_extra_partition*::
+If set, specifies the size (in kilobytes) of an extra partition that
+will be added to the ISO image for persistent storage purposes.
+Currently the file system of this partition will always be XFS. Note
+that an XFS partition must be a minimum of 300MB in size. Therefore,
+if set, the minimum value for this option is 300000. Note that, due to
+the nature of the hybrid ISO image, this partition is only effective
+when the ISO image is used as (USB) disk image. This option has no
+effect (other then making the ISO image larger) when the ISO is burned
+to an optical medium.
+
 *livecd/volid*::
 This option sets the volume ID of the CD created (example: `Gentoo
 Linux 2006.1 X86`).

--- a/targets/embedded/controller.sh
+++ b/targets/embedded/controller.sh
@@ -46,8 +46,9 @@ case ${1} in
 
 	;;
 	livecd-update)
+		shift
 		# Now, finalize and tweak the livecd fs (inside of the chroot)
-		exec_in_chroot  ${clst_shdir}/support/livecdfs-update.sh
+		exec_in_chroot  ${clst_shdir}/support/livecdfs-update.sh ${@}
 	;;
 
 	bootloader)

--- a/targets/embedded/controller.sh
+++ b/targets/embedded/controller.sh
@@ -60,7 +60,7 @@ case ${1} in
 
 	iso)
 		shift
-		${clst_shdir}/support/create-iso.sh ${1}
+		${clst_shdir}/support/create-iso.sh ${@}
 	;;
 
 	clean)

--- a/targets/livecd-stage2/controller.sh
+++ b/targets/livecd-stage2/controller.sh
@@ -164,7 +164,7 @@ case $1 in
 
 	iso)
 		shift
-		${clst_shdir}/support/create-iso.sh $1
+		${clst_shdir}/support/create-iso.sh ${@}
 		;;
 esac
 exit $?

--- a/targets/livecd-stage2/controller.sh
+++ b/targets/livecd-stage2/controller.sh
@@ -55,8 +55,9 @@ case $1 in
 		;;
 
 	livecd-update)
+		shift
 		# Now, finalize and tweak the livecd fs (inside of the chroot)
-		exec_in_chroot ${clst_shdir}/support/livecdfs-update.sh
+		exec_in_chroot ${clst_shdir}/support/livecdfs-update.sh ${@}
 		;;
 
 	rc-update)

--- a/targets/stage4/controller.sh
+++ b/targets/stage4/controller.sh
@@ -40,8 +40,9 @@ case $1 in
 	;;
 
 	livecd-update)
+		shift
 		# Now, finalize and tweak the livecd fs (inside of the chroot)
-		exec_in_chroot ${clst_shdir}/support/livecdfs-update.sh
+		exec_in_chroot ${clst_shdir}/support/livecdfs-update.sh ${@}
 	;;
 
 	bootloader)

--- a/targets/stage4/controller.sh
+++ b/targets/stage4/controller.sh
@@ -61,7 +61,7 @@ case $1 in
 
 	iso)
 		shift
-		${clst_shdir}/support/create-iso.sh $1
+		${clst_shdir}/support/create-iso.sh ${@}
 	;;
 
 	clean)

--- a/targets/support/create-iso.sh
+++ b/targets/support/create-iso.sh
@@ -199,6 +199,24 @@ case ${clst_hostarch} in
 		sparc*) extra_opts+=("--sparc-boot") ;;
 		esac
 
+		# Second argument will specify size in kilobytes
+		if [[ ${2} =~ ^[0-9]+$ ]]; then
+			extrapart=${1%.*}-extra.img
+			rm -f "${extrapart}"
+			dd if=/dev/zero of="${extrapart}" bs=1k count="${2}"
+			# TODO: allow setting different fs type
+			mkfs.xfs "${extrapart}"
+			# 1=ESP, 2=HFS+, so 3 is first available partition
+			extra_opts+=(
+				"-append_partition"
+				"3"
+				"0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+				"${extrapart}"
+			)
+		elif [[ -n ${2} ]]; then
+			die "Invalid second argument, must be an integer"
+		fi
+
 		echo ">> Running grub-mkrescue to create iso image...."
 		grub-mkrescue --mbr-force-bootable -volid "${clst_iso_volume_id}" "${extra_opts[@]}" -o "${1}" "${clst_target_path}"
 	;;

--- a/targets/support/functions.sh
+++ b/targets/support/functions.sh
@@ -17,6 +17,7 @@ exec_in_chroot() {
 	local file_name=$(basename ${1})
 
 	copy_to_chroot ${1}
+	shift
 	copy_to_chroot ${clst_shdir}/support/chroot-functions.sh
 
 	# Ensure the file has the executable bit set
@@ -24,7 +25,7 @@ exec_in_chroot() {
 
 	echo "Running ${file_name} in chroot:"
 	echo "    ${clst_CHROOT} ${clst_chroot_path} /tmp/${file_name}"
-	${clst_CHROOT} "${clst_chroot_path}" "/tmp/${file_name}" || exit 1
+	${clst_CHROOT} "${clst_chroot_path}" "/tmp/${file_name}" "${@}" || exit 1
 
 	delete_from_chroot /tmp/${file_name}
 	delete_from_chroot /tmp/chroot-functions.sh

--- a/targets/support/livecdfs-update.sh
+++ b/targets/support/livecdfs-update.sh
@@ -70,8 +70,17 @@ cat <<EOF > /etc/fstab
 ####################################################
 
 # fstab tweaks
-tmpfs	/					tmpfs	defaults	0 0
+tmpfs				/			tmpfs	defaults	0 0
 EOF
+
+# First argument will contain the mount point of an extra data
+# partition, if any.
+if [[ -n ${1} ]]; then
+	mkdir -p "${1}"
+	cat <<-EOF >> /etc/fstab
+	PARTLABEL=Appended3		${1}		xfs	lazytime	0 2
+	EOF
+fi
 
 mv ${clst_make_conf} ${clst_make_conf}.old
 cat <<EOF > ${clst_make_conf}


### PR DESCRIPTION
This adds a new option for use in the spec files which will toggle the creation of an extra partition in the hybrid ISO image. The partition file system is XFS only (for now), and is intended for use as persistent storage when the ISO is `dd`ed to e.g. an USB drive. The extra partition has no effect when the ISO is burned to an optical medium as partitioning and writing back is not really supported there.

There are a couple of things still to discuss (either now or in a follow-up PR):
- Do we want the file system type to be variable, i.e. add another setting so we can choose something other then XFS?
- Can we change the name of the partition (currently `Appended3`)? Do we want to? The `xorriso` manual is unclear where the name comes from.
- Do we want to automatically mount this partition at boot (i.e. add it to the `fstab`)? If so where should we mount it?

See-also: https://gist.github.com/immolo/16de4fe7907991878585eb2c56e31f27

CC @immolo