### PR TITLE
Disable installkernel chroot check

### DIFF
--- a/targets/support/pre-distkmerge.sh
+++ b/targets/support/pre-distkmerge.sh
@@ -4,4 +4,7 @@ RUN_DEFAULT_FUNCS="yes"
 
 source /tmp/chroot-functions.sh
 
+# Disable chroot check in installkernel
+touch /etc/kernel/install.d/05-check-chroot.install
+
 run_merge --oneshot sys-kernel/dracut


### PR DESCRIPTION
>sys-kernel/installkernel now has a chroot detection script.
This will cause any kernel above 6.16 to error out during the kernel phasee.

This change will disable that test and allow us to use installkernel as we always have.

Testewd on riscv64 diskimage abd amd64 livegui