### PR TITLE
Add Accessibility to GRUB

### DIFF
--- a/targets/support/iso-bootloader-setup.sh
+++ b/targets/support/iso-bootloader-setup.sh
@@ -143,7 +143,17 @@ case ${clst_hostarch} in
 			else
 				echo "	linux ${kern_subdir}/${x} ${default_append_line[@]} docache" >> ${iacfg}
 			fi
-
+			echo "  initrd ${kern_subdir}/${x}.igz" >> ${iacfg}
+			echo "}" >> ${iacfg}
+			echo "" >> ${iacfg}
+			echo "menuentry 'Boot LiveCD (kernel: ${x}) (accessibility)' --class gnu-linux --class os {"  >> ${iacfg}
+			if [ ${distkernel} = "yes" ]
+			then
+				echo "  search --no-floppy --set=root -l ${clst_iso_volume_id}" >> ${iacfg}
+				echo "  linux ${kern_subdir}/${x} ${default_dracut_append_line[@]} dospeakup" >> ${iacfg}
+			else
+				echo "  linux ${kern_subdir}/${x} ${default_append_line[@]} dospeakup" >> ${iacfg}
+			fi
 			echo "	initrd ${kern_subdir}/${x}.igz" >> ${iacfg}
 			echo "}" >> ${iacfg}
 			if [ -n "${kernel_console}" ]


### PR DESCRIPTION
This patch adds a third option under GRUB boot to start espeakup

This requires a new tagged release of livecd-tools to fully work.

I looked into add Braille support as well, but it seems to cause more issues than it solves. Maybe with some feedback with users that need it, we can look again at this.

I play to add support to other bootloader at a later date when I can gain access to hardware at home.

<img width="822" height="713" alt="Screenshot at 2026-02-04 12-05-27" src="https://github.com/user-attachments/assets/a0277a8d-d74a-4d6e-8a63-2d0e9034befb" />
