### PR TITLE
systemd enabled livecds

### DIFF
--- a/catalyst/targets/livecd_stage2.py
+++ b/catalyst/targets/livecd_stage2.py
@@ -35,6 +35,7 @@ class livecd_stage2(StageBase):
         "livecd/readme",
         "livecd/rm",
         "livecd/root_overlay",
+        "livecd/systemd",
         "livecd/type",
         "livecd/unmerge",
         "livecd/users",

--- a/targets/livecd-stage2/controller.sh
+++ b/targets/livecd-stage2/controller.sh
@@ -61,9 +61,14 @@ case $1 in
 		;;
 
 	rc-update)
-		exec_in_chroot ${clst_shdir}/support/rc-update.sh
-		;;
-
+		# Check for systemd enabled livecd
+ 		if [[ ${clst_livecd_systemd} == "yes" ]]; then
+ 			exec_in_chroot ${clst_shdir}/support/systemctl.sh
+ 		else
+ 			# Run as OpenRC
+ 			exec_in_chroot ${clst_shdir}/support/rc-update.sh
+ 		fi
+ 		;;
 	fsscript)
 		exec_in_chroot ${clst_fsscript}
 		;;

--- a/targets/support/systemctl.sh
+++ b/targets/support/systemctl.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script only runs when livecd/systemd: yes is set in the spec
+
+# Configure autologin on tty1 for systemd live media
+mkdir -p /etc/systemd/system/getty@tty1.service.d
+cat > /etc/systemd/system/getty@tty1.service.d/autologin.conf <<EOF
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin root --noclear %I \$TERM
+EOF
+systemctl enable getty@tty1.service
+
+# This section is controlled by the user in the specfile via:
+#   livecd/rcadd: NetworkManager
+#   livecd/rcdel: gpm
+
+if [ -n "${clst_rcadd}" ]
+then
+	for svc in ${clst_rcadd}
+	do
+		echo "Enabling service: ${svc}"
+		systemctl enable "${svc}"
+	done
+fi
+
+if [ -n "${clst_rcdel}" ]
+then
+	for svc in ${clst_rcdel}
+	do
+		echo "Disabling service: ${svc}"
+		systemctl disable "${svc}"
+	done
+fi


### PR DESCRIPTION
Enables livecds to be built with systemd support when the following is added to a spec file:

   `livecd/systemd: yes`

If not set then Catalyst will revert to normal and build for OpenRC.

For now this is basic, but very useable.

`app-misc/livecd-tools` is not used all, although support can be extended into the ebuild for better systemd control at a later date. i.e. It's just not needed at this stage.

Services can be be enabled in spec using:
   `livecd/rcadd: NetworkManager`
or disabled using rcdel.

A service file is created for autologin.

TDLR - This will create a 1:1 version of the installcd, just using systemd rather than OpenRC.

Currently only tested on amd64.