### PR TITLE
stage4: add missing pre-distkmerge controller case for distkernel builds

### DIFF
--- a/targets/stage4/controller.sh
+++ b/targets/stage4/controller.sh
@@ -21,6 +21,12 @@ case $1 in
 		extract_modules ${clst_chroot_path} ${kname}
 	;;
 
+	pre-distkmerge)
+		# Install dracut
+		exec_in_chroot ${clst_shdir}/support/pre-distkmerge.sh
+		;;
+
+
 	build_packages)
 		shift
 		export clst_packages="$*"


### PR DESCRIPTION
When a stage4 spec sets `boot/kernel/<name>/distkernel: yes`, catalyst's `stagebase.py:build_kernel()` calls `controller.sh pre-distkmerge`. The stage4 controller had no case for this action, so it fell through to the default
     `exit 1`, making distkernel stage4 builds impossible.

This patch adds the missing `pre-distkmerge)` case, wiring up the existing `targets/support/pre-distkmerge.sh` script which runs `emerge --oneshot sys-kernel/dracut` inside the chroot before the distributed kernel package is
     merged.